### PR TITLE
Fixed a typo: "Encyrption  -> Encryption"

### DIFF
--- a/content/fact/fulldiskencryption.md
+++ b/content/fact/fulldiskencryption.md
@@ -1,5 +1,5 @@
 ---
-title: "Full Disk Encyrption"
+title: "Full Disk Encryption"
 ---
 
 OpenBSD supports FDE since 5.3 using `softraid(4)` and `bioctl(8)`.


### PR DESCRIPTION
Hey,

I fixed a typo in the "Full Disk Encryption" fact.