### PR TITLE
Spelling issues

### DIFF
--- a/content/fact/pid.md
+++ b/content/fact/pid.md
@@ -2,9 +2,9 @@
 title: "PID randomization"
 ---
 
-OpenBSD has randomized PIDs. That means every process that is being spawned
-thats a random (unused) PID from the operating system. This prevents the user
-from PID prediction attacks.
+OpenBSD has randomized PIDs. That means every process that is spawned
+gets a random (unused) PID from the operating system. This prevents users
+from making PID prediction attacks.
 
 Details:
 


### PR DESCRIPTION
Not sure whether the intent was "protects users from PID prediction attacks" or "prevents users from making PID prediction attacks" so I went with the latter.