### PR TITLE
cwm is a window manager maintained by OpenBSD

### DIFF
--- a/content/fact/cwm.md
+++ b/content/fact/cwm.md
@@ -1,5 +1,5 @@
 ---
-title: "cwm"
+title: "cwm(1)"
 ---
 
 Marius Aamodt Eriksen and a few others developed cwm for X11, which contains 

--- a/content/fact/cwm.md
+++ b/content/fact/cwm.md
@@ -1,0 +1,15 @@
+---
+title: "cwm"
+---
+
+Marius Aamodt Eriksen and a few others developed cwm for X11, which contains 
+many features that concentrate on the efficiency and transparency of window 
+management, while maintaining the simplest and most pleasant aesthetic. cwm
+has replaced wm2 in OpenBSD 4.2, relased November 2007.
+
+Details:
+
+* [Getting started with cwm](https://undeadly.org/cgi?action=article&sid=20090502141551)
+* [OpenBSD 4.2 Release](https://www.openbsd.org/42.html)
+* [OpenBSD 4.2 Changelog](https://www.openbsd.org/plus42.html)
+* [Calm Window Manager - Wikipedia](https://en.wikipedia.org/wiki/Cwm_(window_manager))


### PR DESCRIPTION
For your consideration. 

cwm isn't apart of 'base', because it's installed with an extra set - X11: https://www.openbsd.org/faq/faq4.html#FilesNeeded
However, it is maintained and developed for OpenBSD