### PR TITLE
Add more to fact about enable/disabling audio recording

### DIFF
--- a/content/fact/audio.md
+++ b/content/fact/audio.md
@@ -3,7 +3,8 @@ title: "Audio recording"
 ---
 
 For privacy reasons, the OpenBSD team disabled audio recording for all
-devices by default in the kernel.
+devices by default in the kernel. This can be toggled on/off with a simple
+sysctl change, without rebooting.
 
 Details:
 


### PR DESCRIPTION
Just want to clarify that recording audio can easily be enabled/disabled. It does require su privileges, though.  Should we assume users would already know that?