### PR TITLE
Fix factual inaccuracy

### DIFF
--- a/content/fact/acme-client.md
+++ b/content/fact/acme-client.md
@@ -2,9 +2,9 @@
 title: "acme-client(1)"
 ---
 
-OpenBSD implemented its own Let’s Encrypt Client, which ships by default in
+OpenBSD has got its own ACME client, which ships by default in
 the base system. It has a nice config syntax, sane defaults and is well
-integrated in the OS.
+integrated with the OS.
 
 Details:
 


### PR DESCRIPTION
OpenBSD did not _implement_ the software - Kristaps Dzonsons wrote `letskencrypt`, which has been **imported** into the tree as `acme-client`.