### PR TITLE
Improve apostrophe utilization

### DIFF
--- a/content/fact/ifconfig-mac-address.md
+++ b/content/fact/ifconfig-mac-address.md
@@ -2,7 +2,7 @@
 title: "Random MAC addresses in ifconfig(8)"
 ---
 
-OpenBSD let's you have randomized MAC addresses via `ifconfig(8)`
+OpenBSD lets you have randomized MAC addresses via `ifconfig(8)`
 
 ```
 ifconfig iwm0 lladdr random

--- a/content/fact/syscall-from-verification.md
+++ b/content/fact/syscall-from-verification.md
@@ -3,7 +3,7 @@ title: "Syscall From-Verification"
 ---
 
 From OpenBSD 6.7 on, the kernel checks if a syscall is executed from the address
-space where it's corresponding process is coming from. If this is not the
+space where its corresponding process is coming from. If this is not the
 case, the process gets killed.
 
 This helps avoiding attackers uploading exploit code containing a raw system call


### PR DESCRIPTION
"Its" can be used in place of "It's" to show ownership[^1]. "Lets" can be used instead of "Let's" as a synonym for "allows" or "enables"[^2].

Amazing site, btw. It's a big part of what originally helped me decide to try OpenBSD.

[^1]: https://www.merriam-webster.com/words-at-play/when-to-use-its-vs-its
[^2]: https://www.grammarly.com/blog/lets-vs-lets/