### PR TITLE
Wifi Pluralization Proposal

### DIFF
--- a/content/fact/ifconfig-mac-address.md
+++ b/content/fact/ifconfig-mac-address.md
@@ -9,7 +9,7 @@ ifconfig iwm0 lladdr random
 ```
 
 Randomizing your MAC address improves anonymity while using your Laptop in
-public wifi's or the like.
+public wifi or the like.
 
 Details:
 


### PR DESCRIPTION
This commit substitutes "Laptop in public wifi's" with "Laptop in public wifi". I did not include this with #86, because it is more speculative on my part.

"Wifi's" is not the correct pluralization[^1], but I couldn't find a clear alternative. Unhelpfully, Merriam-Webster's entry for "Wi-Fi" lists no information about an acceptable plural form[^2]. While the Wiktionary entry for Wi-fi claims[^3] that "Wi-Fi" can be **countable** (like cars), no citation is given. I *believe* that "Wi-Fi" is strictly **uncountable** (like gas[^4]) and therefore does not need to be pluralized, but I can't find anything online to back up such a claim.

Interestingly, dictionaries seem to prefer "Wi-Fi" over "wifi" since it is a certification mark[^5], but I agree strongly with your spelling; I don't think many practicioners would find the capitalized, hyphenated form natural in an informal setting.

[^1]: https://www.grammarly.com/blog/apostrophe/ (§ "Apostrophes and Plurals")
[^2]: https://www.merriam-webster.com/dictionary/Wi-Fi
[^3]: https://en.wiktionary.org/wiki/Wi-Fi#Noun
[^4]: https://youtu.be/IOJXRs_V5Cw
[^5]: https://www.merriam-webster.com/dictionary/certification%20mark