### PR TITLE
Repleace "gcc" with clang in base-system-concept.md

### DIFF
--- a/content/fact/base-system-concept.md
+++ b/content/fact/base-system-concept.md
@@ -6,7 +6,7 @@ When you install OpenBSD, you get a base system that contains various
 software.
 
 For example, `sshd`, `tmux`, a HTTP Server, `whois` , `doas`, `less`, `make`,
-`gcc`  & `ftp`. Mostly stuff that is needed day to day by a system
+`clang`  & `ftp`. Mostly stuff that is needed day to day by a system
 administrator.
 
 A base system with default tools and daemons is a fundamentally different


### PR DESCRIPTION
By default, OpenBSD comes with `clang` instead of `gcc`: