### PR TITLE
Corrected my claim about -fwrapv flag in OpenBSD compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ to be added as facts:
 * ipstack interface validation https://undeadly.org/cgi?action=article;sid=20191209024432
 * libressl 6.8: New X509 certificate chain validator that correctly handles multiple paths through intermediate certificates. Loosely based on Go's X509 validator
 * explicit_bzero(3)
+* BSD make and include files for makefiles at /usr/share/mk/

--- a/content/fact/defined-integer-overflows.md
+++ b/content/fact/defined-integer-overflows.md
@@ -1,10 +1,11 @@
 ---
-title: "clang -fwrapv"
+title: "Defined integer overflows"
 ---
 
 Clang, the default compiler on most architectures,
 have `-fwrapv` flag enabled by default.
-This option tells the compiler to treat signed integer overflows as defined,
+GCC also does not include `-fstrict-overflow` into `-O2` optimization option.
+This tells the compiler to treat signed integer overflows as defined,
 preventing optimizations which remove security critical overflow checks.
 This is another example of [sane defaults](/fact/sane-defaults/).
 
@@ -12,4 +13,5 @@ Details:
 
 * [clang-local(1) - OpenBSD manual pages](https://man.openbsd.org/clang-local.1)
 * [clang(1) - OpenBSD manual pages](https://man.openbsd.org/clang.1)
-
+* [gcc-local(1) - OpenBSD manual pages](https://man.openbsd.org/gcc-local.1)
+* [gcc(1) - OpenBSD manual pages](https://man.openbsd.org/gcc.1)


### PR DESCRIPTION
I renamed `clang-fwrapv.md` into `defined-integer-overflows.md`
In this file i mentioned that `-fstrict-overflow` is disabled in gcc, even when `-O2` optimization option is turned on.
And i am also mentioned idea about include files for BSD make placed at `/usr/share/mk/` in README.md

Hope now all claims are correct.